### PR TITLE
SIMD: add vectorized functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ endforeach(flag)
 # Release flags
 # Debug flags
 set(RELEASE_CXX_FLAGS
-  -O3 -flto -DNDEBUG
+  -O3 -DNDEBUG
   -msse4.1
 )
 foreach(flag ${RELEASE_CXX_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,12 @@ foreach(flag ${DEBUG_CXX_FLAGS})
 endforeach(flag)
 
 # Release flags
-foreach(flag -O3 -flto -DNDEBUG)
+# Debug flags
+set(RELEASE_CXX_FLAGS
+  -O3 -flto -DNDEBUG
+  -msse4.1
+)
+foreach(flag ${RELEASE_CXX_FLAGS})
   check_cxx_compiler_flag(${flag} has_flag_${flag})
   if(has_flag_${flag})
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${flag}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,8 @@ include(GNUInstallDirs)
 set(LIB_SRC
   ${SOURCE_DIR}/core.cpp
   ${SOURCE_DIR}/misc.cpp
+  ${SOURCE_DIR}/gf_nf4.cpp
+  ${SOURCE_DIR}/gf_ring.cpp
   ${SOURCE_DIR}/property.cpp
   ${SOURCE_DIR}/vec_vector.cpp
 

--- a/src/gf_nf4.cpp
+++ b/src/gf_nf4.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017-2018 the NTTEC authors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gf_nf4.h"
+#include "simd.h"
+
+namespace nttec {
+namespace gf {
+
+template <>
+__uint128_t NF4<__uint128_t>::expand16(uint16_t* arr)
+{
+    return simd::expand16(arr, this->n);
+}
+
+template <>
+__uint128_t NF4<__uint128_t>::expand32(uint32_t* arr)
+{
+    return simd::expand32(arr, this->n);
+}
+
+template <>
+__uint128_t NF4<__uint128_t>::add(__uint128_t a, __uint128_t b)
+{
+    return simd::add(a, b);
+}
+
+template <>
+__uint128_t NF4<__uint128_t>::sub(__uint128_t a, __uint128_t b)
+{
+    return simd::sub(a, b);
+}
+
+template <>
+__uint128_t NF4<__uint128_t>::mul(__uint128_t a, __uint128_t b)
+{
+    return simd::mul(a, b);
+}
+
+template <>
+void NF4<__uint128_t>::add(int n, __uint128_t* x, __uint128_t* y)
+{
+    simd::add_buf_to_two_bufs(n, x, y);
+}
+
+template <>
+void NF4<__uint128_t>::hadamard_mul(int n, __uint128_t* x, __uint128_t* y)
+{
+    simd::hadamard_mul(n, x, y);
+}
+
+template <>
+GroupedValues<__uint128_t> NF4<__uint128_t>::unpack(__uint128_t a)
+{
+    return simd::unpack(a, this->n);
+}
+
+template <>
+__uint128_t NF4<__uint128_t>::pack(__uint128_t a)
+{
+    return simd::pack(a);
+}
+
+template <>
+__uint128_t NF4<__uint128_t>::pack(__uint128_t a, uint32_t flag)
+{
+    return simd::pack(a, flag);
+}
+
+} // namespace gf
+} // namespace nttec

--- a/src/gf_nf4.h
+++ b/src/gf_nf4.h
@@ -73,6 +73,8 @@ class NF4 : public gf::Field<T> {
     T get_nth_root(T n);
     void compute_omegas(vec::Vector<T>* W, int n, T w);
     gf::Field<uint32_t>* get_sub_field();
+    void hadamard_mul(int n, T* x, T* y);
+    void add(int n, T* x, T* y);
 
   private:
     T unit;
@@ -120,8 +122,11 @@ bool NF4<T>::check_n(unsigned n)
     return (n <= sizeof(T) / 4);
 }
 
+template <>
+__uint128_t NF4<__uint128_t>::expand16(uint16_t* arr);
+
 template <typename T>
-inline T NF4<T>::expand16(uint16_t* arr)
+T NF4<T>::expand16(uint16_t* arr)
 {
     T c = arr[this->n - 1];
     for (int i = this->n - 2; i >= 0; i--) {
@@ -130,8 +135,11 @@ inline T NF4<T>::expand16(uint16_t* arr)
     return c;
 }
 
+template <>
+__uint128_t NF4<__uint128_t>::expand32(uint32_t* arr);
+
 template <typename T>
-inline T NF4<T>::expand32(uint32_t* arr)
+T NF4<T>::expand32(uint32_t* arr)
 {
     T c = arr[this->n - 1];
     for (int i = this->n - 2; i >= 0; i--) {
@@ -192,6 +200,9 @@ T NF4<T>::neg(T a)
     return sub(0, a);
 }
 
+template <>
+__uint128_t NF4<__uint128_t>::add(__uint128_t a, __uint128_t b);
+
 template <typename T>
 T NF4<T>::add(T a, T b)
 {
@@ -208,6 +219,9 @@ T NF4<T>::add(T a, T b)
 
     return c;
 }
+
+template <>
+__uint128_t NF4<__uint128_t>::sub(__uint128_t a, __uint128_t b);
 
 template <typename T>
 T NF4<T>::sub(T a, T b)
@@ -236,6 +250,9 @@ T NF4<T>::sub(T a, T b)
 
     return c;
 }
+
+template <>
+__uint128_t NF4<__uint128_t>::mul(__uint128_t a, __uint128_t b);
 
 template <typename T>
 T NF4<T>::mul(T a, T b)
@@ -345,6 +362,9 @@ T NF4<T>::weak_rand(void)
     return unpack(c).values;
 }
 
+template <>
+__uint128_t NF4<__uint128_t>::pack(__uint128_t a);
+
 /**
  * Pack of n numbers each of 16 bits into n numbers each of 32 bits
  */
@@ -361,6 +381,9 @@ T NF4<T>::pack(T a)
     T c = expand32(arr);
     return c;
 }
+
+template <>
+__uint128_t NF4<__uint128_t>::pack(__uint128_t a, uint32_t flag);
 
 /**
  * Pack of n numbers each of 16 bits into n numbers each of 32 bits
@@ -386,6 +409,9 @@ T NF4<T>::pack(T a, uint32_t flag)
     T c = expand32(arr);
     return c;
 }
+
+template <>
+GroupedValues<__uint128_t> NF4<__uint128_t>::unpack(__uint128_t a);
 
 /**
  * Unpack of n numbers each of 32 bits into n numbers each of 16 bits
@@ -455,6 +481,24 @@ template <typename T>
 gf::Field<uint32_t>* NF4<T>::get_sub_field()
 {
     return sub_field;
+}
+
+template <>
+void NF4<__uint128_t>::hadamard_mul(int n, __uint128_t* x, __uint128_t* y);
+
+template <typename T>
+void NF4<T>::hadamard_mul(int n, T* x, T* y)
+{
+    return;
+}
+
+template <>
+void NF4<__uint128_t>::add(int n, __uint128_t* x, __uint128_t* y);
+
+template <typename T>
+void NF4<T>::add(int n, T* x, T* y)
+{
+    return;
 }
 
 } // namespace gf

--- a/src/gf_ring.cpp
+++ b/src/gf_ring.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2018 the NTTEC authors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gf_ring.h"
+#include "simd.h"
+
+namespace nttec {
+namespace gf {
+
+template <>
+void RingModN<uint32_t>::mul_coef_to_buf(
+    uint32_t a,
+    uint32_t* src,
+    uint32_t* dest,
+    size_t len)
+{
+    simd::mul_coef_to_buf(a, src, dest, len, this->_card);
+}
+
+template <>
+void RingModN<uint32_t>::add_two_bufs(uint32_t* src, uint32_t* dest, size_t len)
+{
+    simd::add_two_bufs(src, dest, len, this->_card);
+}
+
+} // namespace gf
+} // namespace nttec

--- a/src/gf_ring.h
+++ b/src/gf_ring.h
@@ -106,6 +106,8 @@ class RingModN {
     virtual T get_nth_root(T n);
     T get_code_len(T n);
     T get_code_len_high_compo(T n);
+    virtual void hadamard_mul(int n, T* x, T* y){};
+    virtual void add(int n, T* x, T* y){};
 
   private:
     T _card;
@@ -347,6 +349,12 @@ void RingModN<T>::mul_coef_to_buf(T a, T* src, T* dest, size_t len)
         dest[i] = T((coef * src[i]) % this->_card);
     }
 }
+template <>
+void RingModN<uint32_t>::mul_coef_to_buf(
+    uint32_t a,
+    uint32_t* src,
+    uint32_t* dest,
+    size_t len);
 
 template <typename T>
 void RingModN<T>::mul_vec_to_vecp(
@@ -372,6 +380,12 @@ void RingModN<T>::add_two_bufs(T* src, T* dest, size_t len)
         dest[i] = (src[i] + dest[i]) % this->_card;
     }
 }
+
+template <>
+void RingModN<uint32_t>::add_two_bufs(
+    uint32_t* src,
+    uint32_t* dest,
+    size_t len);
 
 template <typename T>
 void RingModN<T>::add_vecp_to_vecp(vec::Buffers<T>* src, vec::Buffers<T>* dest)

--- a/src/simd.h
+++ b/src/simd.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2018 the NTTEC authors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __NTTEC_SIMD_H__
+#define __NTTEC_SIMD_H__
+
+// FIXME: detect SIMD flags since it requires SSE4.1 instructions
+#include "simd_128.h"
+
+#endif

--- a/src/simd_128.h
+++ b/src/simd_128.h
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2017-2018 the NTTEC authors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __NTTEC_SIMD_128_H__
+#define __NTTEC_SIMD_128_H__
+
+#include <x86intrin.h>
+
+namespace nttec {
+
+/** The namespace simd contains functions that are accelerated by using SIMD
+ *  operations over 128bits
+ *
+ *  Currently, it supports operations on 32-bit numbers
+ */
+namespace simd {
+
+/* ==================== Essential Operations =================== */
+
+const uint32_t F4 = 65537;
+const uint32_t F3 = 257;
+const __m128i F4_m128i = _mm_set1_epi32(65537);
+const __m128i F4minus1_m128i = _mm_set1_epi32(65536);
+const __m128i F3_m128i = _mm_set1_epi32(257);
+const __m128i F3minus1_m128i = _mm_set1_epi32(256);
+
+/** Return __uint128_t integer from a _m128i register */
+static inline __uint128_t m128i_to_uint128(__m128i v)
+{
+    __uint128_t i;
+    _mm_storeu_si128((__m128i*)&i, v);
+
+    return i; // NOLINT(clang-analyzer-core.uninitialized.UndefReturn)
+}
+
+/** Perform a%card where a is a addition of two numbers whose elements are
+ *  symbols of GF(card) */
+inline __uint128_t mod_after_add(__m128i a, uint32_t card)
+{
+    const __m128i _card = _mm_set1_epi32(card);
+    const __m128i _card_minus_1 = _mm_set1_epi32(card - 1);
+
+    __m128i cmp = _mm_cmpgt_epi32(a, _card_minus_1);
+    __m128i b = _mm_sub_epi32(a, _mm_and_si128(_card, cmp));
+
+    return m128i_to_uint128(b);
+}
+
+/** Perform addition of two numbers a, b whose elements are of GF(card) */
+inline __uint128_t add(__uint128_t a, __uint128_t b, uint32_t card = F4)
+{
+    __m128i _a = _mm_loadu_si128((__m128i*)&a);
+    __m128i _b = _mm_loadu_si128((__m128i*)&b);
+    __m128i c = _mm_add_epi32(_a, _b);
+
+    // Modulo
+    return mod_after_add(c, card);
+}
+
+/** Perform subtraction of a by b where a, b whose elements are symbols of
+ *  GF(card)
+ * sub(a, b) = a - b if a >= b, or
+ *             card + a - b, otherwise
+ */
+inline __uint128_t sub(__uint128_t a, __uint128_t b, uint32_t card = F4)
+{
+    const __m128i _card = _mm_set1_epi32(card);
+
+    __m128i _a = _mm_loadu_si128((__m128i*)&a);
+    __m128i _b = _mm_loadu_si128((__m128i*)&b);
+
+    __m128i cmp = _mm_cmpgt_epi32(_b, _a);
+    __m128i _a1 = _mm_add_epi32(_a, _mm_and_si128(_card, cmp));
+
+    __m128i c = _mm_sub_epi32(_a1, _b);
+
+    return m128i_to_uint128(c);
+}
+
+/** Perform a%card where a is a multiplication of two numbers whose elements are
+ *  symbols of GF(F4)
+ *
+ *  We find v in a = u * card + v
+ *  a is expressed also as: a = hi * (card-1) + lo
+ *  where hi and lo is 16-bit for F4 (or 8-bit for F3) high and low parts of a
+ *  hence, v = (lo - hi) % F4
+ *      v = lo - hi, if lo >= hi
+ *          or
+ *          F4 + lo - hi, otherwise
+ */
+inline __uint128_t mod_after_multiply_f4(__m128i a)
+{
+    const __m128i mask = _mm_set1_epi32(F4 - 2);
+
+    __m128i lo = _mm_and_si128(a, mask);
+
+    __m128i a_shift = _mm_srli_si128(a, 2);
+    __m128i hi = _mm_and_si128(a_shift, mask);
+
+    __m128i cmp = _mm_cmpgt_epi32(hi, lo);
+    __m128i _lo = _mm_add_epi32(lo, _mm_and_si128(F4_m128i, cmp));
+
+    __m128i b = _mm_sub_epi32(_lo, hi);
+
+    return m128i_to_uint128(b);
+}
+
+inline __uint128_t mod_after_multiply_f3(__m128i a)
+{
+    const __m128i mask = _mm_set1_epi32(F3 - 2);
+
+    __m128i lo = _mm_and_si128(a, mask);
+
+    __m128i a_shift = _mm_srli_si128(a, 1);
+    __m128i hi = _mm_and_si128(a_shift, mask);
+
+    __m128i cmp = _mm_cmpgt_epi32(hi, lo);
+    __m128i _lo = _mm_add_epi32(lo, _mm_and_si128(F3_m128i, cmp));
+
+    __m128i b = _mm_sub_epi32(_lo, hi);
+
+    return m128i_to_uint128(b);
+}
+
+inline __uint128_t mul_f4(__uint128_t a, __uint128_t b)
+{
+    __m128i _a = _mm_loadu_si128((__m128i*)&a);
+    __m128i _b = _mm_loadu_si128((__m128i*)&b);
+
+    __m128i c = _mm_mullo_epi32(_a, _b);
+
+    // filter elements of both of a & b = card-1
+    __m128i cmp = _mm_and_si128(
+        _mm_cmpeq_epi32(_a, F4minus1_m128i),
+        _mm_cmpeq_epi32(_b, F4minus1_m128i));
+
+    const __m128i one = _mm_set1_epi32(1);
+    c = _mm_add_epi32(c, _mm_and_si128(one, cmp));
+
+    // Modulo
+    return mod_after_multiply_f4(c);
+}
+
+inline __uint128_t mul_f3(__uint128_t a, __uint128_t b)
+{
+    __m128i _a = _mm_loadu_si128((__m128i*)&a);
+    __m128i _b = _mm_loadu_si128((__m128i*)&b);
+
+    __m128i c = _mm_mullo_epi32(_a, _b);
+
+    // filter elements of both of a & b = card-1
+    __m128i cmp = _mm_and_si128(
+        _mm_cmpeq_epi32(_a, F3minus1_m128i),
+        _mm_cmpeq_epi32(_b, F3minus1_m128i));
+
+    c = _mm_xor_si128(c, _mm_and_si128(F3_m128i, cmp));
+
+    // Modulo
+    return mod_after_multiply_f3(c);
+}
+
+/** Perform multiplication of two numbers a, b whose elements are of GF(card)
+ *  where `card` is a prime Fermat number, i.e. card = Fx with x < 5
+ *  Currently, it supports only for F3 and F4
+ */
+inline __uint128_t mul(__uint128_t a, __uint128_t b, uint32_t card = F4)
+{
+    assert(card == F4 || card == F3);
+    if (card == F4)
+        return mul_f4(a, b);
+    return mul_f3(a, b);
+}
+
+/** Perform a multiplication of a coefficient `a` to each element of `src` and
+ *  add result to correspondent element of `dest`
+ */
+inline void mul_coef_to_buf(
+    const uint32_t a,
+    uint32_t* src,
+    uint32_t* dest,
+    size_t len,
+    uint32_t card = F4)
+{
+    const __m128i _coef = _mm_set1_epi32(a);
+    __uint128_t coef = m128i_to_uint128(_coef);
+
+    __uint128_t* _src = static_cast<__uint128_t*>(static_cast<void*>(src));
+    __uint128_t* _dest = static_cast<__uint128_t*>(static_cast<void*>(dest));
+    size_t _len = len / 4;
+    size_t _last_len = len - _len * 4;
+
+    size_t i;
+    for (i = 0; i < _len; i++) {
+        // perform multiplication
+        _dest[i] = mul(coef, _src[i], card);
+    }
+    if (_last_len > 0) {
+        uint64_t coef_64 = (uint64_t)a;
+        for (i = _len * 4; i < len; i++) {
+            // perform multiplication
+            dest[i] = (uint32_t)((coef_64 * src[i]) % card);
+        }
+    }
+}
+
+inline void
+add_two_bufs(uint32_t* src, uint32_t* dest, size_t len, uint32_t card = F4)
+{
+    __uint128_t* _src = static_cast<__uint128_t*>(static_cast<void*>(src));
+    __uint128_t* _dest = static_cast<__uint128_t*>(static_cast<void*>(dest));
+    size_t _len = len / 4;
+    size_t _last_len = len - _len * 4;
+
+    size_t i;
+    for (i = 0; i < _len; i++) {
+        // perform addition
+        _dest[i] = add(_src[i], _dest[i], card);
+    }
+    if (_last_len > 0) {
+        for (i = _len * 4; i < len; i++) {
+            // perform addition
+            uint32_t tmp = src[i] + dest[i];
+            dest[i] = (tmp >= card) ? (tmp - card) : tmp;
+        }
+    }
+}
+
+/* ==================== Operations for NF4 =================== */
+
+inline __uint128_t expand16(uint16_t* arr, int n)
+{
+    // since n <= 4
+    uint16_t _arr[4] = {0, 0, 0, 0};
+    std::copy_n(arr, n, _arr);
+
+    __m128i b = _mm_set_epi64(
+        _mm_setzero_si64(), _mm_set_pi16(_arr[3], _arr[2], _arr[1], _arr[0]));
+
+    return m128i_to_uint128(b);
+}
+
+inline __uint128_t expand32(uint32_t* arr, int n)
+{
+    // since n <= 4
+    uint32_t _arr[4] = {0, 0, 0, 0};
+    std::copy_n(arr, n, _arr);
+
+    __m128i b = _mm_set_epi32(_arr[3], _arr[2], _arr[1], _arr[0]);
+
+    return m128i_to_uint128(b);
+}
+
+/** Add buffer `y` to two halves of `x`. `x` is of length `n` */
+inline void add_buf_to_two_bufs(int n, __uint128_t* x, __uint128_t* y)
+{
+    int i;
+    int half = n / 2;
+    __uint128_t* x_next = x + half;
+
+    // add y to the first half of `x`
+    for (i = 0; i < half; i++) {
+        x[i] = add(x[i], y[i]);
+    }
+
+    // add y to the second half of `x`
+    for (i = 0; i < half; i++) {
+        x_next[i] = add(x_next[i], y[i]);
+    }
+}
+
+inline void hadamard_mul(int n, __uint128_t* x, __uint128_t* y)
+{
+    int i;
+    int half = n / 2;
+    __uint128_t* x_next = x + half;
+
+    // multiply y to the first half of `x`
+    for (i = 0; i < half; i++) {
+        x[i] = mul(x[i], y[i]);
+    }
+
+    // multiply y to the second half of `x`
+    for (i = 0; i < half; i++) {
+        x_next[i] = mul(x_next[i], y[i]);
+    }
+}
+
+inline GroupedValues<__uint128_t> unpack(__uint128_t a, int n)
+{
+    uint32_t flag = 0;
+    uint32_t ai[4];
+    uint16_t bi[4] = {0, 0, 0, 0};
+    __uint128_t values;
+    int i;
+
+    __m128i _a = _mm_loadu_si128((__m128i*)&a);
+    ai[0] = _mm_extract_epi32(_a, 0);
+    ai[1] = _mm_extract_epi32(_a, 1);
+    ai[2] = _mm_extract_epi32(_a, 2);
+    ai[3] = _mm_extract_epi32(_a, 3);
+    for (i = 0; i < n; i++) {
+        if (ai[i] == 65536)
+            flag |= (1 << i);
+        else
+            bi[i] = (uint16_t)ai[i];
+    }
+    __m128i val = _mm_set_epi64(
+        _mm_setzero_si64(), _mm_set_pi16(bi[3], bi[2], bi[1], bi[0]));
+    _mm_storeu_si128((__m128i*)&values, val);
+
+    GroupedValues<__uint128_t> b = {values, flag};
+
+    return b;
+}
+
+inline __uint128_t pack(__uint128_t a)
+{
+    __m128i _a = _mm_loadu_si128((__m128i*)&a);
+    __m128i b = _mm_set_epi32(
+        _mm_extract_epi16(_a, 3),
+        _mm_extract_epi16(_a, 2),
+        _mm_extract_epi16(_a, 1),
+        _mm_extract_epi16(_a, 0));
+
+    return m128i_to_uint128(b);
+}
+
+inline __uint128_t pack(__uint128_t a, uint32_t flag)
+{
+    uint32_t b0, b1, b2, b3;
+    __m128i _a = _mm_loadu_si128((__m128i*)&a);
+
+    if (flag & 1)
+        b0 = 65536;
+    else
+        b0 = _mm_extract_epi16(_a, 0);
+    flag >>= 1;
+    if (flag & 1)
+        b1 = 65536;
+    else
+        b1 = _mm_extract_epi16(_a, 1);
+    flag >>= 1;
+    if (flag & 1)
+        b2 = 65536;
+    else
+        b2 = _mm_extract_epi16(_a, 2);
+    flag >>= 1;
+    if (flag & 1)
+        b3 = 65536;
+    else
+        b3 = _mm_extract_epi16(_a, 3);
+
+    __m128i b = _mm_set_epi32(b3, b2, b1, b0);
+
+    return m128i_to_uint128(b);
+}
+
+} // namespace simd
+} // namespace nttec
+
+#endif

--- a/src/vec_vector.cpp
+++ b/src/vec_vector.cpp
@@ -240,5 +240,27 @@ void Vector<uint64_t>::add(Doubled<uint64_t>* v)
         mem[i] = rn->add(mem[i], src[j]);
 }
 
+template <>
+void Vector<__uint128_t>::hadamard_mul(Doubled<__uint128_t>* v)
+{
+    assert(n == v->get_n());
+
+    // typical butterfly operation
+    __uint128_t* a = get_mem();
+    __uint128_t* b = v->get_mem();
+    rn->hadamard_mul(n, a, b);
+}
+
+template <>
+void Vector<__uint128_t>::add(Doubled<__uint128_t>* v)
+{
+    assert(n == v->get_n());
+
+    // typical butterfly operation
+    __uint128_t* a = get_mem();
+    __uint128_t* b = v->get_mem();
+    rn->add(n, a, b);
+}
+
 } // namespace vec
 } // namespace nttec


### PR DESCRIPTION
Currently, it supports only for CPUID SSE4.1
Supported components:
- gf::nf4 and fec::rs-nf4 for (w=8, t=16)
- vec::Buffers and fec::fnt for (w=1,2 and t=4)