### PR TITLE
add a note about using clang for Apple systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ fragmentation systematic codes are not necessarily useful.
 mkdir build
 cd build
 cmake -G 'Unix Makefiles' ..
+# CXX=clang++ cmake -G 'Unix Makefiles' ..
 make
 ```
+
+**WARNING**: If you are compiling the code from an Apple system, you must use
+Clang (the GCC provided by Apple has buggy code generation for SIMD).
 
 ### Targets
 


### PR DESCRIPTION
After a long investigation, it seems like the GCC provided by Apple has
a bug when generating SIMD code from compiler intrinsics.

It happens when some combinations of optimization and inlining occurs:
it converts a `_mm_and_si128` into a `psrld` of 31 bits instead of a
`pand`.