### PR TITLE
update the README about the compiler bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ fragmentation systematic codes are not necessarily useful.
 mkdir build
 cd build
 cmake -G 'Unix Makefiles' ..
-# CXX=clang++ cmake -G 'Unix Makefiles' ..
 make
 ```
 
-**WARNING**: If you are compiling the code from an Apple system, you must use
-Clang (the GCC provided by Apple has buggy code generation for SIMD).
+**WARNING**: If you are compiling the code with Clang, don't use a 4.X version:
+there is [a bug](https://bugs.llvm.org/show_bug.cgi?id=36723) that affects SIMD
+code in NTTEC.
 
 ### Targets
 


### PR DESCRIPTION
After more testing, it appears that the bug is not specific to Apple (I
reproduced it on Linux as well): it is a bug in the 4.X branch of
Clang/LLVM (I reported it here
https://bugs.llvm.org/show_bug.cgi?id=36723).

This commit updates the README accordingly.